### PR TITLE
style: refactor for UI cleanup

### DIFF
--- a/components/Layout.module.css
+++ b/components/Layout.module.css
@@ -1,0 +1,32 @@
+.header {
+  padding: 15px;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 9;
+  background-color: var(--header-bg);
+  border-bottom: 1px solid var(--table-border);
+}
+.wrapper {
+  max-width: var(--max-width);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 0 auto;
+}
+.header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.header span {
+  font-size: small;
+}
+
+@media screen and (max-width: 768px) {
+  .header span {
+    display: none;
+  }
+  
+}

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,0 +1,30 @@
+import HeartApollorion from "@/components/HeartApollorion";
+import ReportIssue from "@/components/ReportIssue";
+import SearchBar from "./SearchBar";
+import styles from "./Layout.module.css";
+
+type Props = {
+    children: React.ReactNode;
+    item: string;
+    version: string;
+}
+
+export default function Layout({children, item, version}: Props) {
+    return (
+        <>  
+            <header className={styles.header}>
+                <div className={styles.wrapper}>
+                    <div>
+                        <h1>Manifests.io</h1>
+                        <span>Easy to use online kubernetes documentation</span>
+                    </div>
+                    <SearchBar pageItem={item} pageVersion={version} />
+                </div>
+            </header>
+                {children}
+            <footer style={{ display: 'flex', justifyContent: 'center'}}>
+                <HeartApollorion />
+            </footer>
+        </>
+    )
+}

--- a/components/ResourceTable.module.css
+++ b/components/ResourceTable.module.css
@@ -1,0 +1,43 @@
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+  position: relative;
+}
+.table tr {
+  padding: 10px;
+  border-bottom: 1px solid var(--table-border);
+}
+.table td {
+  padding: 10px;
+}
+.table td:nth-of-type(2n+1) {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.table th {
+  text-align: left;
+  font-weight:bold;
+  padding: 10px;
+}
+.table p {
+  white-space: pre-line;
+  word-break: break-word;
+}
+
+@media screen and (max-width:768px) {
+  .table tr, .table td {
+    display: block;
+    font-size: 14px;
+  }
+  .table td:nth-of-type(2n) {
+    padding-top: 0;
+  }
+  .table th:first-of-type {
+    display:none;
+  }
+  .table th {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+}

--- a/components/ResourceTable.tsx
+++ b/components/ResourceTable.tsx
@@ -1,3 +1,5 @@
+import styles from "./ResourceTable.module.css";
+
 type Resource = {
     resource: string;
     description: string;
@@ -32,21 +34,21 @@ export default function ResourceTable({leftHeading, resources, item, version, li
     }
 
     return (
-        <table style={{width: "100%", borderCollapse: "collapse", marginTop: "1rem"}}>
+        <table className={styles.table}>
             <thead>
-            <tr style={{padding: "10px", borderBottom: "1pt solid var(--table-border)", backgroundColor: "var(--table-heading-bg)"}}>
-                <td style={{padding: "10px"}}><b>{leftHeading}</b></td>
-                <td style={{padding: "10px"}}><b>Description</b></td>
+            <tr style={{backgroundColor: "var(--table-heading-bg)"}}>
+                <th>{leftHeading}</th>
+                <th>Description</th>
             </tr>
             </thead>
             <tbody>
             {resources.map((resource) => (
-                <tr key={resource.resource} style={{padding: "10px", borderBottom: "1pt solid var(--table-border)"}}>
-                    <td style={{padding: "10px", whiteSpace: "nowrap"}}>
+                <tr key={resource.resource}>
+                    <td>
                         <b>{resource.links ? <a href={generateLink(resource)}><span className="link">{resource.resource}</span> 🔗</a> : resource.resource}</b><br/>
                         <small>{resource.type} {generateRequiredStar(resource.resource)}</small>
                     </td>
-                    <td style={{padding: "10px"}}><p style={{whiteSpace: "pre-line"}}>{resource.description}</p></td>
+                    <td><p>{resource.description}</p></td>
                 </tr>
             ))}
             </tbody>

--- a/components/SearchBar.module.css
+++ b/components/SearchBar.module.css
@@ -1,0 +1,25 @@
+.selector {
+  display: flex;
+  align-items: center;
+}
+.selector label {
+  font-size: .9rem;
+  margin-right: .5rem;
+}
+.selector select {
+  padding: .4rem;
+  font-size: 1.1rem;
+}
+
+@media screen and (max-width: 768px) {
+  .selector select {
+    padding: .25rem;
+    font-size: 1rem;
+  } 
+}
+
+@media screen and (max-width: 500px) {
+  .selector label {
+    display: none;
+  }
+}

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -1,4 +1,5 @@
 import {availableItemVersions} from "@/lib/oaspec";
+import styles from "./SearchBar.module.css";
 
 function SearchBar({pageItem, pageVersion}: {pageItem: string, pageVersion: string}){
     const itemVersions = availableItemVersions();
@@ -8,9 +9,9 @@ function SearchBar({pageItem, pageVersion}: {pageItem: string, pageVersion: stri
     }
 
     return (
-        <div>
+        <div className={styles.selector}>
+            <label htmlFor="product">Choose a spec:</label>
             <select
-                style={{width: "50ch", textAlignLast: "center"}}
                 name="product"
                 id="product"
                 defaultValue={`/${pageItem}/${pageVersion}`}

--- a/pages/[item]/[version]/[resource]/index.tsx
+++ b/pages/[item]/[version]/[resource]/index.tsx
@@ -1,7 +1,7 @@
-import Head from 'next/head'
 import styles from '@/styles/Home.module.css'
 import {GetServerSideProps} from "next";
 import { oaspecFetch } from "@/lib/oaspec";
+import Layout from '@/components/Layout';
 import SearchBar from "@/components/SearchBar";
 import ResourceTable from "@/components/ResourceTable";
 import ReportIssue from "@/components/ReportIssue";
@@ -41,7 +41,7 @@ function Gvk({gvk}: {gvk: Array<{group: string, kind: string, version: string}>}
 
 export default function Home({resources, item, version, linkedResource, description, resource, gvk, required}: Props) {
     return (
-        <>
+        <Layout item={item} version={version}>
             <ManifestsHeading
                 item={item}
                 version={version}
@@ -49,8 +49,6 @@ export default function Home({resources, item, version, linkedResource, descript
                 resource={resource}
             />
             <main className={styles.main}>
-                <HeartApollorion />
-                <SearchBar pageItem={item} pageVersion={version} />
                 <h1 style={{marginTop: "20px", marginBottom: "50px"}}>{linkedResource}</h1>
                 {gvk && (
                     <div style={{marginTop: "-30px", marginBottom: "30px", textAlign: "center"}}>
@@ -62,7 +60,7 @@ export default function Home({resources, item, version, linkedResource, descript
                 <ResourceTable leftHeading="Key" required={required} resources={resources} item={item} version={version} linkedResource={linkedResource} />
                 <ReportIssue resource={resource} item={item} />
             </main>
-        </>
+        </Layout>
     )
 }
 

--- a/pages/[item]/[version]/index.tsx
+++ b/pages/[item]/[version]/index.tsx
@@ -2,6 +2,7 @@ import Head from 'next/head'
 import styles from '@/styles/Home.module.css'
 import {GetServerSideProps} from "next";
 import { oaspecFetch } from "@/lib/oaspec";
+import Layout from '@/components/Layout';
 import HeartApollorion from "@/components/HeartApollorion";
 import SearchBar from "@/components/SearchBar";
 import ResourceTable from "@/components/ResourceTable";
@@ -24,23 +25,25 @@ type Props = {
 
 export default function Home({resources, item, version}: Props) {
     return (
-        <>
+        <Layout item={item} version={version}>
             <ManifestsHeading
                 item={item}
                 version={version}
                 description={""}
             />
             <main className={styles.main}>
-                <HeartApollorion />
-                <SearchBar pageItem={item} pageVersion={version} />
-                <p style={{marginTop: "50px", marginBottom: "20px", textAlign: "center"}}>
-                    Available resources for {item} version {version}.<br/>
-                    Your browsers url supports all resources in the {item} openAPI spec, even if a resource is not listed here.
-                </p>
+                <div className={styles.intro}>
+                    <h3>
+                        Available resources for <code>{item}</code> version <code>{version}</code>
+                    </h3>
+                    <p>
+                        Your browsers url supports all resources in the {item} openAPI spec, even if a resource is not listed here.
+                    </p>
+                </div>
                 <ResourceTable leftHeading="Object" resources={resources} item={item} version={version} />
                 <ReportIssue item={item} />
             </main>
-        </>
+        </Layout>
     )
 }
 

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -5,4 +5,21 @@
   min-height: 100vh;
   max-width: var(--max-width);
   margin: 0 auto;
+  padding-top: 80px;
+}
+
+.intro {
+  margin-top: 40px;
+  margin-bottom: 20px;
+  width: 100%;
+}
+
+.intro h3 {
+  font-weight: normal;
+  font-size: 1.2rem;
+  margin-bottom: 0.4rem;
+}
+
+.intro code {
+  font-weight: bold;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,6 +1,5 @@
 :root {
   --max-width: 1100px;
-  --border-radius: 12px;
   --font-mono: ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono',
     'Roboto Mono', 'Oxygen Mono', 'Ubuntu Monospace', 'Source Code Pro',
     'Fira Mono', 'Droid Sans Mono', 'Courier New', monospace;
@@ -8,31 +7,6 @@
   --foreground-rgb: 0, 0, 0;
   --background-start-rgb: 214, 219, 220;
   --background-end-rgb: 255, 255, 255;
-
-  --primary-glow: conic-gradient(
-    from 180deg at 50% 50%,
-    #16abff33 0deg,
-    #0885ff33 55deg,
-    #54d6ff33 120deg,
-    #0071ff33 160deg,
-    transparent 360deg
-  );
-  --secondary-glow: radial-gradient(
-    rgba(255, 255, 255, 1),
-    rgba(255, 255, 255, 0)
-  );
-
-  --tile-start-rgb: 239, 245, 249;
-  --tile-end-rgb: 228, 232, 233;
-  --tile-border: conic-gradient(
-    #00000080,
-    #00000040,
-    #00000030,
-    #00000020,
-    #00000010,
-    #00000010,
-    #00000080
-  );
 
   --callout-rgb: 238, 240, 241;
   --callout-border-rgb: 172, 175, 176;
@@ -48,26 +22,6 @@
     --foreground-rgb: 255, 255, 255;
     --background-start-rgb: 0, 0, 0;
     --background-end-rgb: 0, 0, 0;
-
-    --primary-glow: radial-gradient(rgba(1, 65, 255, 0.4), rgba(1, 65, 255, 0));
-    --secondary-glow: linear-gradient(
-      to bottom right,
-      rgba(1, 65, 255, 0),
-      rgba(1, 65, 255, 0),
-      rgba(1, 65, 255, 0.3)
-    );
-
-    --tile-start-rgb: 2, 13, 46;
-    --tile-end-rgb: 2, 5, 19;
-    --tile-border: conic-gradient(
-      #ffffff80,
-      #ffffff40,
-      #ffffff30,
-      #ffffff20,
-      #ffffff10,
-      #ffffff10,
-      #ffffff80
-    );
 
     --callout-rgb: 20, 20, 20;
     --callout-border-rgb: 108, 108, 108;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -13,6 +13,7 @@
   --card-rgb: 180, 185, 188;
   --card-border-rgb: 131, 134, 135;
 
+  --header-bg: rgba(255,255,255,.75);
   --table-border: #666;
   --table-heading-bg: #f0f0f0;
 }
@@ -28,6 +29,7 @@
     --card-rgb: 100, 100, 100;
     --card-border-rgb: 200, 200, 200;
 
+    --header-bg: rgba(0,0,0,.75);
     --table-border: #444;
     --table-heading-bg: #222;
   }


### PR DESCRIPTION
I initially intended to only fix the responsive usability glitch, but I got carried away while refactoring the CSS modules. While I didn't touch your application logic at all, some of these changes might cause merge conflict with whatever branch you're currently working on.

Please feel free to reject it if concerned about merge conflicts. The intended changes include:

- Adjust the `word-break` property to avoid mobile viewport content overflow glitch.
    -  This was caused by a very long URL strings in certain paragraphs, which didn't break into multiple lines because of a particular CSS property. Now fixed.
- Separate out most of inline CSS styles for better maintenance and finer style control
- Separate out repeating page elements to a parent `<Layout />` component 
- Adjust overall layout to:
    - add a global fixed header module
    - show the application name
    - place the dropdown selector inside the header
    - make clear which spec details are currently in view

